### PR TITLE
fix(menu-service): display new menu

### DIFF
--- a/src/app/layout/header/menus.service.ts
+++ b/src/app/layout/header/menus.service.ts
@@ -37,6 +37,10 @@ export class MenusService {
             name: 'Analyze',
             path: ''
           }, {
+          name: 'Launcher',
+          feature: 'AppLauncher',
+          path: '/_applauncher'
+        }, {
             name: 'Plan',
             feature: 'Planner',
             path: 'plan',


### PR DESCRIPTION
@dlabrecq adding an entry for appLauncher in menu service. Now you should be able to see your new menu.
![screenshot 2018-02-01 14 36 00_preview](https://user-images.githubusercontent.com/1395710/35681309-43df72ee-075d-11e8-8091-86b867c2463f.png)
